### PR TITLE
Pass-through postgres connection option 'statement_timeout'

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -79,7 +79,9 @@ class ConnectionManager extends AbstractConnectionManager {
           'binary',
           // This should help with backends incorrectly considering idle clients to be dead and prematurely disconnecting them.
           // this feature has been added in pg module v6.0.0, check pg/CHANGELOG.md
-          'keepAlive'
+          'keepAlive',
+          // Times out queries after a set time in milliseconds. Added in pg v7.3
+          'statement_timeout'
         ]));
     }
 


### PR DESCRIPTION
node-postgres recently added support for 'statement_timeout' -- a per connection query timeout.

See

- https://github.com/brianc/node-postgres/pull/1436
- [postgres connection docs](https://www.postgresql.org/docs/9.4/static/runtime-config-client.html)

