### PR TITLE
Pass-through postgres connection option 'statement_timeout'

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -79,7 +79,9 @@ class ConnectionManager extends AbstractConnectionManager {
           'binary',
           // This should help with backends incorrectly considering idle clients to be dead and prematurely disconnecting them.
           // this feature has been added in pg module v6.0.0, check pg/CHANGELOG.md
-          'keepAlive'
+          'keepAlive',
+          // Times out queries after a set time in milliseconds. Added in pg v7.3
+          'statement_timeout'
         ]));
     }
 


### PR DESCRIPTION
node-postgres recently added support for 'statement_timeout' -- a per connection query timeout.

See

- https://github.com/brianc/node-postgres/pull/1436

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
